### PR TITLE
Make data mapping optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Backbone Despotism
-A Backbone replacement model that enforces property declarations. 
+A Backbone replacement model that enforces property declarations.
 Exposes a model called `Backbone.StrictModel`.
 
 ## Creating a model with a properties definition
@@ -52,9 +52,5 @@ var MyStrictModel = Backbone.StrictModel.extend({
 });
 ```
 
-In the example above, doing `new MyStrictModel({ firstName: "Göran" })` will
-result in a model with `{ "name": "Göran" }`. However, when just setting
-properties, you will need to be explicit about wanting to use the foreign
-mappings. For example, `myModelInstance.set({ firstName: "Sven" })` will have
-no effect on the model instance, but
-`myModelInstance.set({ firstName: "Sven" }, { useForeignKeys: true })` will.
+In the example above, doing `new MyStrictModel({ firstName: "Göran" },
+{ useForeignKeys: true })` will result in a model with `{ "name": "Göran" }`.

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.5",
+  "version": "0.2.0",
   "name": "backbone-despotism",
   "main": "backbone-despotism.js",
   "dependencies": {

--- a/test/modules/model-tests.js
+++ b/test/modules/model-tests.js
@@ -42,7 +42,7 @@ describe("Backbone Despotism", function() {
     model.set({
       firstName: "James",
       lastName: "Cauty"
-    });
+    }, { useForeignKeys: true });
     assert.deepEqual(model.attributes, {
       firstName: "James",
       lastName: "Cauty"
@@ -51,7 +51,7 @@ describe("Backbone Despotism", function() {
     model.set({
       firstName: "James",
       surname: "Cauty"
-    });
+    }, { useForeignKeys: true });
     assert.deepEqual(model.attributes, {
       firstName: "James",
       lastName: "Cauty"
@@ -61,7 +61,7 @@ describe("Backbone Despotism", function() {
       firstName: "James",
       lastName: "Cauty",
       surname: "Drummond"
-    });
+    }, { useForeignKeys: true });
     assert.deepEqual(model.attributes, {
       firstName: "James",
       lastName: "Cauty"
@@ -95,7 +95,7 @@ describe("Backbone Despotism", function() {
       lastName: "Drummond"
     }, "Ignores default value if value exists");
   });
-  
+
   // Testing defaults with foreign keys
   it("Uses foreign keys with default values", function() {
     var MyStrictModel = Backbone.StrictModel.extend({
@@ -114,7 +114,7 @@ describe("Backbone Despotism", function() {
     model.set({
       firstName: "James",
       lastName: "Cauty"
-    });
+    }, { useForeignKeys: true });
     assert.deepEqual(model.attributes, {
       firstName: "James",
       lastName: "Cauty"
@@ -123,7 +123,7 @@ describe("Backbone Despotism", function() {
     model.set({
       firstName: "James",
       surname: "Cauty"
-    });
+    }, { useForeignKeys: true });
     assert.deepEqual(model.attributes, {
       firstName: "James",
       lastName: "Cauty"
@@ -133,7 +133,7 @@ describe("Backbone Despotism", function() {
       firstName: "James",
       lastName: "Cauty",
       surname: "Timelord"
-    });
+    }, { useForeignKeys: true });
     assert.deepEqual(model.attributes, {
       firstName: "James",
       lastName: "Cauty"
@@ -142,7 +142,7 @@ describe("Backbone Despotism", function() {
     model.set({
       firstName: "James",
       surname: "Cauty"
-    });
+    }, { useForeignKeys: true });
     assert.deepEqual(model.attributes, {
       firstName: "James",
       lastName: "Cauty"


### PR DESCRIPTION
What it says in the title. As a bonus `model.clear` starts working again for strict models.

Note: this is a breaking change.